### PR TITLE
検索画面、募集一覧、募集詳細の仮実装

### DIFF
--- a/backend/init_db.js
+++ b/backend/init_db.js
@@ -20,17 +20,23 @@ const init = async function() {
         age: '22'
     });
     await models.Gather.create({
-        user_id: 2,
-        title: 'Hello',
-        content: 'World'
-    });
-    await models.Gather.create({
         user_id: 1,
         title: 'Good girl',
-        content: 'Good boy'
+        content: 'Good boy',
+        good: 0,
+        bad: 0,
+        secret: false
     });
     await models.Gather.create({
-        user_id: 1,
+        user_id: 2,
+        title: 'Hello',
+        content: 'World',
+        good: 0,
+        bad: 0,
+        secret: false
+    });
+    await models.Gather.create({
+        user_id: 3,
         title: 'test',
         content: 'test',
         good: 0,

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2,11 +2,13 @@
   <div id="app">
     <div id="nav">
       <router-link to="/">Home</router-link> |
+      <router-link to="/search">Search</router-link> |
       <router-link to="/about">About</router-link> |
       <router-link to="/edithobby">Post Hobby</router-link> |
       <router-link to="/postGather">Post Gather</router-link> |
       <router-link to="/showHobby">Show Hobby</router-link> |
-      <router-link to="/login">Login</router-link>
+      <router-link to="/login">Login</router-link>|
+      <router-link to="/showGather">Show Gather</router-link>
     </div>
     <router-view/>
   </div>

--- a/frontend/src/components/GatherDetails/Comment.vue
+++ b/frontend/src/components/GatherDetails/Comment.vue
@@ -1,0 +1,102 @@
+<template>
+    <div class="comment">
+        <div class="info">
+            <div class="user" v-if="item.secret">
+                匿名ユーザー
+            </div>
+            <div class="user" v-else>
+                {{ comment.username }}
+            </div>
+            <div class="good">
+                <button v-on:click="clickgood">
+                    <i class="far fa-thumbs-up"></i>いいね
+                </button>：{{ comment.good }}
+            </div>
+            <div class="bad">
+                <button v-on:click="clickbad">
+                    <i class="far fa-thumbs-up"></i>よくないね
+                </button>：{{ comment.bad }}
+            </div>
+        </div>
+        <div class="comment">
+            {{ comment.comment }}
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'Comment',
+    props: ['item', 'id'],
+    data: function(){
+        return {
+            comment: this.item,
+        };
+    },
+    methods: {
+        //need to change
+        clickgood: function(){
+            this.axios.put('/api/hobby/comment/good/' + this.id)
+            .then((res) => {
+                if(res.status === 200){
+                    this.comment.good++;
+                }else{
+                    alert('Server Error');
+                }
+            })
+            .catch((e) => alert(e));
+        },
+        clickbad: function(){
+            this.axios.put('/api/hobby/comment/bad/' + this.id)
+            .then((res) => {
+                if(res.status === 200){
+                    this.comment.bad++;
+                }else{
+                    alert('Server Error');
+                }
+            })
+            .catch((e) => console.log(e));
+        }
+    },
+    watch: {
+        item: function(newValue){
+            this.comment = newValue;
+        }
+    }
+}
+</script>
+
+<style scoped>
+.info{
+    display: flex;
+}
+
+.user{
+    width: 30%;
+}
+
+.good .bad{
+    width: 15%;
+}
+
+.good {
+    margin-right: 10%;
+}
+
+button {
+    border-radius: 15px;
+    font-weight: bold;
+    background: #00ff8c;
+    border-color: black;
+    color: #2c3e50;
+}
+
+button:hover {
+    background-color: #008d4e;
+}
+
+i {
+    color: rgb(255, 255, 255);
+    margin-right: 5px;
+}
+</style>

--- a/frontend/src/components/GatherDetails/CommentList.vue
+++ b/frontend/src/components/GatherDetails/CommentList.vue
@@ -1,0 +1,55 @@
+<template>
+    <RecycleScroller
+        class="scroller"
+        :items="list"
+        :item-size="32"
+        key-field="id"
+        v-slot="{ item }"
+    >
+    <Comment v-bind:item="item" v-bind:id="id"></Comment>
+    </RecycleScroller>
+</template>
+
+<script>
+import Comment from '@/components/GatherDetails/Comment.vue'
+
+export default {
+    name: 'CommentList',
+    props: {
+        list: Array,
+        id: Number,
+    },
+    components: {
+        Comment,
+    },
+    watch: {
+        list: function(newValue){
+            this.list = newValue;
+        },
+        id: function(newValue){
+            this.id = newValue;
+        }
+    }
+}
+</script>
+
+<style scoped>
+.scroller{
+    text-align: left;
+    margin-left: 20%;
+}
+
+.info{
+    display: flex;
+}
+
+.user{
+    width: 30%;
+}
+
+.good .bad{
+    width: 15%;
+    margin-right: 10%;
+}
+
+</style>

--- a/frontend/src/components/GatherDetails/Content.vue
+++ b/frontend/src/components/GatherDetails/Content.vue
@@ -1,0 +1,156 @@
+<template>
+    <div class="content">
+        <div 
+            class="title"
+            v-for="gatherdetail in content" 
+            :key="gatherdetail.title"
+        >
+            <!-- この書き方やばそう -->
+            <div v-if="gatherdetail.id === Number(gatherinfo.id)">
+                <div>
+                    <h1>{{gatherdetail.title}}</h1>
+                    <!--ユーザーの判別条件をv-ifでつける-->
+                    <div class="editbutton">
+                        <router-link to="/postGather" v-bind:hobby="gatherdetail">
+                        <i class="fas fa-edit"></i>編集
+                    </router-link>
+                    </div>
+                </div>
+                <div class="editor">投稿者： ダミー(変更する必要あり)</div>
+                <p class="text">{{gatherdetail.content}}</p>
+                <div class="reputation">
+                    <div class="good">
+                        <button v-on:click="clickgood">
+                            <i class="far fa-thumbs-up"></i>いいね
+                        </button>：{{ gatherdetail.good }}
+                    </div>
+                    <div class="bad">
+                        <button v-on:click="clickbad">
+                            <i class="far fa-thumbs-down"></i>よくないね
+                        </button>：{{ gatherdetail.bad }}
+                    </div>
+                     <!-- <button v-on:click="show">確認用</button> -->
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'Content',
+    props: {
+        detail: Object
+    },
+    data: function(){
+        return {
+            content: this.detail,
+            gatherinfo: this.$route.params
+        };
+    },
+    methods: {
+        edit: function(){
+            this.content.title = 'change';
+            this.$emit('edited', this.content);
+        },
+        //need to change
+        clickgood: function(){
+            this.axios.put('/api/hobby/good/'+this.content.id)
+            .then((res) => {
+                if(res.status === 200){
+                    this.content.good++;
+                }else{
+                    console.log('Server Error');
+                }
+            })
+            .catch((e) => alert(e));
+        },
+        clickbad: function(){
+            this.axios.put('/api/hobby/bad/'+this.content.id)
+            .then((res) => {
+                if(res.status === 200){
+                    this.content.bad++;
+                }else{
+                    console.log('Server Error');
+                }
+            })
+            .catch((e) => console.log(e));
+        },
+        
+        // show(){
+        //     this.content.id = this.gatherinfo.id
+        //     console.log("this.gatherinfo",this.gatherinfo)
+        //     console.log("this.content",this.content)
+        // }
+    },
+    watch: {
+        detail: function(newValue){
+            this.content = newValue;
+        }
+    }
+}
+</script>
+
+<style scoped>
+.content{
+    text-align: left;
+    margin-left: 20%;
+}
+
+.title{
+    display: flex;
+    clear: both;
+    align-items: baseline;
+}
+
+h1 {
+    margin-right: 30px;
+}
+
+.editbutton{
+    text-align: right;
+}
+
+.editbutton i {
+    margin-right: 5px;
+}
+
+.editor{
+    clear: both;
+    text-align: left;
+}
+
+.text{
+    font-size: 28px;
+}
+
+.reputation {
+    display: flex;
+    padding-bottom: 60px;
+    padding-top: 30px;
+}
+
+.good {
+    margin-right: 20%;
+}
+
+
+button {
+    border-radius: 15px;
+    font-weight: bold;
+    background: #00ff8c;
+    border-color: black;
+    color: #2c3e50;
+}
+
+button:hover {
+    background-color: #008d4e;
+}
+
+.reputation i {
+    color: rgb(255, 255, 255);
+    margin-right: 5px;
+}
+
+
+</style>

--- a/frontend/src/components/Search/search.vue
+++ b/frontend/src/components/Search/search.vue
@@ -1,0 +1,66 @@
+<template>
+    <div>
+        <input type="text" v-model="keyword">
+        <button @click="search">検索</button>
+        <div>
+            <input type="checkbox" v-model="gatherchange">趣味の募集を検索
+            <input type="checkbox" v-model="hobbychange">趣味の投稿を検索
+        </div>
+        <div v-if="gatherchange===true">
+            <div v-for="gatherdataset in gatherdatalist" :key="gatherdataset.user_id">
+                <router-link :to="`/gatherdetail/${gatherdataset.user_id}`">
+                    <div class="card">
+                        <h3 class="card-header">タイトル：{{ gatherdataset.title }}</h3>
+                        <div class="card-body">内容：{{ gatherdataset.content }}</div>
+                    </div>
+                </router-link>
+            </div>
+        </div> 
+        <div v-if="hobbychange===true">
+            <div v-for="hobbydataset in hobbydatalist" :key="hobbydataset.user_id">
+                <router-link :to="`/hobbydetail/${hobbydataset.user_id}`">
+                    <div class="card">
+                        <h3 class="card-header">タイトル：{{ hobbydataset.title }}</h3>
+                        <div class="card-body">内容：{{ hobbydataset.content }}</div>
+                    </div>
+                </router-link>
+            </div>
+        </div>           
+    </div>
+</template>
+
+<script>
+export default {
+    data() {
+        return{
+    keyword: '',
+    gatherdatalist: {},
+    hobbydatalist: {},
+    hobbychange: false,
+    gatherchange: false,
+        }
+}, 
+methods:{
+     search(){
+         if (this.gatherchange === true){
+            this.axios.get('/api/gather/search/'+this.keyword)
+            .then((res) => {
+                this.gatherdatalist = res.data;
+                console.log("this.gather",this.gatherdatalist)
+            }).catch((err) => {
+                alert(err);
+            });
+        }
+        if (this.hobbychange === true){
+            this.axios.get('/api/hobby/search/'+this.keyword)
+            .then((res) => {
+                this.hobbydatalist = res.data;
+                console.log("this.hobby",this.hobbydatalist)
+            }).catch((err) => {
+                alert(err);
+            });            
+        }
+    }
+},
+}
+</script>

--- a/frontend/src/components/ShowGather.vue
+++ b/frontend/src/components/ShowGather.vue
@@ -1,0 +1,40 @@
+<template>
+ <div id="ShowGather">
+  <div class="container">
+   <h1 v-if="gather_list.length">Gather list</h1>
+   <h1 v-else>No openings. </h1>
+
+   <div v-for="gather in gather_list" :key="gather.id">
+    <div class="card">
+      <router-link v-bind:to="'/gatherdetail/' + gather.id" v-bind:id="gather.id"><h3 class="card-header">{{ gather.title }}</h3></router-link>
+     <div class="card-body">{{ gather.content }}</div>
+    </div>
+    <br>
+    </div>
+
+
+  </div>
+ </div>
+</template>
+
+<script>
+export default {
+  name: 'ShowGather',
+  data : function(){
+   return {
+    gather_list : []
+  }
+  },
+  mounted : function(){ 
+    this.axios.get("api/gather/lists").then((res) => {
+      this.gather_list = res.data;
+      }).catch((err) =>{
+       console.log(err);
+       });
+            },
+}
+</script>
+
+<style scoped>
+    
+</style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -6,6 +6,9 @@ import EditHobby from '../views/EditHobby.vue'
 import LoginView from '../views/Login.vue'
 import PostGatherView from "../views/PostGather.vue"
 import ShowHobbyView from "../views/ShowHobby.vue"
+import ShowGather from "../views/ShowGather.vue"
+import GatherDetails from '../views/GatherDetails.vue'
+import Search from "../views/Search"
 
 
 Vue.use(VueRouter)
@@ -53,6 +56,23 @@ const routes = [
     name: 'showHobbyView',
     component: ShowHobbyView,
     props: true
+  },
+  {
+    path: '/showGather',
+    name: 'showGatherView',
+    component: ShowGather,
+    props: true
+  },
+  {
+    path: '/gatherdetail/:id',
+    name: 'gatherdetail',
+    component: GatherDetails,
+    props: true
+  },
+  {
+    path: '/search',
+    name: 'Search',
+    component: Search
   },
 
 ]

--- a/frontend/src/views/GatherDetails.vue
+++ b/frontend/src/views/GatherDetails.vue
@@ -1,0 +1,102 @@
+<template>
+    <div>
+        <GatherDetail :detail="gather"></GatherDetail>
+        <!-- dbにgatherコメント未実装 -->
+        <!-- <CommentList v-bind:list="testData" v-bind:id="this.hobby.id"></CommentList> -->
+        <div class="inputform">
+            <input type="text" class="comment" v-model="comment">
+            <div class="secret">
+                <input type="checkbox" v-model="secret">匿名
+            </div>
+            <button class="submit" v-on:click="submitclick">
+                <i class="far fa-paper-plane"></i>送信
+            </button>
+        </div>
+    </div>
+</template>
+
+
+<script>
+import GatherDetail from '../components/GatherDetails/Content'
+// import CommentList from '../components/HobbyDetails/CommentList.vue'
+
+export default {
+    name: 'GatherDetails',
+    components: {
+        GatherDetail,
+        // CommentList
+    },
+    data: function(){
+        return {
+            gather: {},
+            testData: [],
+            gather_id: this.$route.params.id,  // need to change
+            comment: '',
+            secret: false
+        };
+    },
+    mounted: function(){
+        this.axios.get('/api/gather/lists')
+        .then((res) => {
+            this.gather = res.data;
+        }).catch((err) => {
+            alert(err);
+        });
+    },
+    methods: {
+        submitclick: function(){
+            if(!this.comment){
+                alert('コメントを入力してください');
+                return;
+            }
+            //コメントの実装が必要そう
+            this.axios.post('/api/hobby/add/comments/', {
+                hobby_id: this.hobby.id,
+                user_id: this.user_id, //need to change
+                comment: this.comment,
+                secret: this.secret
+            }).then((res) => {
+                this.testData = res.data;
+                this.comment = '';
+                this.secret = false;
+            }).catch((err) => {
+                alert(err);
+            });
+        },
+        onedited: function(newData){
+            this.hobby = newData;
+        }
+    }
+}
+</script>
+
+<style scoped>
+.inputform{
+    display: flex;
+    margin-left: 20%;
+}
+.comment {
+    text-align: left;
+    width: 60%;
+}
+.secret{
+    margin-left: 10px;
+    margin-right: 10px;
+}
+button {
+    border-radius: 15px;
+    font-weight: bold;
+    background: #00ff8c;
+    border-color: black;
+    color: #2c3e50;
+}
+
+button:hover {
+    background-color: #008d4e;
+}
+
+i {
+    color: rgb(255, 255, 255);
+    margin-right: 5px;
+}
+</style>

--- a/frontend/src/views/Search.vue
+++ b/frontend/src/views/Search.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    <h1>検索ページ</h1>
+    <Search></Search>
+  </div>
+</template>
+
+<script>
+import Search from "../components/Search/search";
+export default {
+  components: {
+        Search,
+    },
+}
+</script>

--- a/frontend/src/views/ShowGather.vue
+++ b/frontend/src/views/ShowGather.vue
@@ -1,0 +1,16 @@
+<template>
+ <div> 
+  <h1>Show Gather page</h1>
+  <ShowGather/>
+ </div>
+</template>
+
+<script>
+import ShowGather from "../components/ShowGather.vue"
+export default {
+ name : "ShowGatherView",
+ components : {
+    ShowGather
+ }
+}
+</script>


### PR DESCRIPTION
- 一旦フロント一部
- [x] 検索画面 
- [x] 募集一覧
- [x] 募集詳細

<img width="1085" alt="スクリーンショット 2021-01-09 21 43 38" src="https://user-images.githubusercontent.com/69241625/104091896-cc065700-52c3-11eb-9649-dbc743af2edb.png">

## **残りタスク（急いでやる)**
- フロント
募集詳細に userが紐付いてないから紐付ける
トップページのヘッダー部分 <- これは何を作れば良いのかよくわかってない
- バック
いいね、よくないね機能 
ログイン機能 
趣味と募集に関する削除、編集機能